### PR TITLE
Fix async tests for MCP server

### DIFF
--- a/simple_mcp_test.py
+++ b/simple_mcp_test.py
@@ -3,6 +3,9 @@ import asyncio
 import json
 import subprocess
 import sys
+import pytest
+
+pytestmark = pytest.mark.asyncio
 
 async def test_mcp_server():
     print("🧪 Testing AI Development Team MCP Server...")

--- a/test_mcp.py
+++ b/test_mcp.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 import asyncio
 import json
+import pytest
 from mcp.client.session import ClientSession
 from mcp.client.stdio import stdio_client
+
+pytestmark = pytest.mark.asyncio
 
 async def test_mcp_server():
     print("🧪 Testing AI Development Team MCP Server...")


### PR DESCRIPTION
## Summary
- mark async tests with `pytest.mark.asyncio`
- install pytest-asyncio in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866da9f1fb083248c6e8ce0d3ab7e32