### PR TITLE
Add agent list command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+\nai-dev-env/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ This repository contains a simple example of an **AI-based development team**. I
 - **Tests** – Scripts such as `test_mcp.py` and `simple_mcp_test.py` show how to interact with the server.
 - **Configuration** – Example systemd service and MCP configuration are located in the `config/` folder.
 - **`LM_STUDIO_SETUP.md`** – Detailed guide for running the project with LM Studio as a local language model.
+- **`verify_agents.py`** – Diagnostic script to confirm all AI agents respond correctly.
+- **`project_templates/`** – Jinja2 templates used when generating new projects.
+- **`config/docker-compose.dev.yml`** – Example Docker Compose setup with Postgres and Redis.
+- **`scripts/`** – Helper scripts for environment setup, backups and updates.
+- **`list_agents` tool** – Inspect available AI agents and their roles through the MCP server.
 
 ## Setup
 
@@ -45,6 +50,7 @@ The `cli.py` tool provides a simple way to interact with the server without the 
 ```bash
 python cli.py create my-project "My project description"
 python cli.py list
+python cli.py agents
 ```
 
 ### Docker

--- a/cli.py
+++ b/cli.py
@@ -22,5 +22,15 @@ def list():
     else:
         typer.echo("No projects found")
 
+
+@app.command()
+def agents():
+    """List available automated agents"""
+    result = asyncio.run(call_tool("list_agents", {}))
+    if result:
+        typer.echo(result[0].text)
+    else:
+        typer.echo("No agents found")
+
 if __name__ == "__main__":
     app()

--- a/test_verify_agents.py
+++ b/test_verify_agents.py
@@ -1,0 +1,4 @@
+import verify_agents
+
+def test_verify_agents():
+    assert verify_agents.verify_agents() is True


### PR DESCRIPTION
## Summary
- extend CLI with an `agents` command for listing automated agents
- document the new command in the README
- add simple verification test
- ignore local virtual env dir

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b0d050b48324b83ab283fb9f93d2