### PR TITLE
Add Llama installation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository contains a simple example of an **AI-based development team**. I
 
 ## Setup
 
-1. Run the installation script which sets up the environment, checks for LM Studio and runs the tests:
+1. Run the installation script which sets up the environment, checks for LM Studio and runs the tests. If LM Studio is not running a helper script will install a local Llama backend automatically:
    ```bash
    ./scripts/install.sh
    ```

--- a/scripts/install_llama.sh
+++ b/scripts/install_llama.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Install and test Llama if LM Studio or Llama server is not detected
+set -e
+
+LM_STUDIO_URL="http://localhost:1234/v1/models"
+
+# Check LM Studio server
+if curl -sf "$LM_STUDIO_URL" > /dev/null; then
+    echo "✅ LM Studio server detected"
+    exit 0
+fi
+
+# Activate virtual environment if present
+if [ -d "ai-dev-env" ]; then
+    source ai-dev-env/bin/activate
+fi
+
+# Install llama-cpp-python if not installed
+if ! python - <<'PY'
+import importlib.util
+raise SystemExit(0 if importlib.util.find_spec('llama_cpp') else 1)
+PY
+then
+    echo "Installing llama-cpp-python..."
+    pip install --upgrade llama-cpp-python
+fi
+
+# Test llama installation
+python - <<'PY'
+try:
+    import llama_cpp
+    print('✅ llama-cpp-python import successful')
+except Exception as e:
+    print('❌ Failed to import llama-cpp-python', e)
+    raise
+PY
+
+# Write default llama settings
+cat > config/llama_settings.json <<'CONF'
+{
+  "provider": "llama_cpp",
+  "model_path": "/path/to/model.gguf",
+  "n_ctx": 2048
+}
+CONF
+
+echo "✅ Llama settings written to config/llama_settings.json"
+
+exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,4 +7,7 @@ source ai-dev-env/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
+echo "Checking for LM Studio or local Llama installation..."
+./scripts/install_llama.sh
+
 echo "✅ Environment ready. Activate with: source ai-dev-env/bin/activate"


### PR DESCRIPTION
## Summary
- ensure LM Studio or Llama is installed during setup
- new `install_llama.sh` checks for LM Studio, installs `llama-cpp-python` and writes settings
- call helper from `setup.sh`
- document automatic Llama setup in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6869e9b388e08324b84cc2d6adf84713