### PR TITLE
Add start script for repo update and launch

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Simple start script for AI Development Team
+# Updates repository, ensures dependencies and launches the server.
+set -e
+
+# Update repository
+if [ -d .git ]; then
+    echo "🔄 Updating repository..."
+    git pull --ff-only
+fi
+
+# Setup Python virtual environment
+if [ ! -d "ai-dev-env" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv ai-dev-env
+fi
+source ai-dev-env/bin/activate
+
+# Install requirements
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Optional additional setup
+if [ -x ./scripts/install_llama.sh ]; then
+    ./scripts/install_llama.sh || true
+fi
+
+# Start the MCP server
+exec python ai_dev_team_server.py "$@"


### PR DESCRIPTION
## Summary
- create `start.sh` to handle git updates, environment setup, dependency install, optional llama setup and launching of the MCP server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_6869ebe5793c832482a1e2b809a2c45d