### PR TITLE
Add tests for create_simple_project and web frontend

### DIFF
--- a/tests/test_create_simple_project.py
+++ b/tests/test_create_simple_project.py
@@ -1,0 +1,28 @@
+import asyncio
+import os
+import types
+import pytest
+
+import ai_dev_team_server as server
+
+@pytest.mark.asyncio
+async def test_call_tool_creates_project(tmp_path, monkeypatch):
+    # Use a temporary directory for project creation
+    server.WORK_DIR = str(tmp_path)
+    server.projects.clear()
+
+    result = await server.call_tool(
+        "create_simple_project",
+        {"name": "demo", "description": "demo project"},
+    )
+
+    assert isinstance(result, list)
+    assert result and "created" in result[0].text
+
+    project_dir = tmp_path / "demo"
+    assert (project_dir / "README.md").exists()
+    assert (project_dir / "src" / "main.py").exists()
+
+    # listing should include the project name
+    list_result = await server.call_tool("list_projects", {})
+    assert any("demo" in block.text for block in list_result)

--- a/tests/test_web_frontend.py
+++ b/tests/test_web_frontend.py
@@ -1,0 +1,34 @@
+import pytest
+
+import web_frontend
+from flask import Flask
+
+class FakeContent:
+    def __init__(self, text):
+        self.text = text
+
+class FakeResult:
+    def __init__(self, text):
+        self.content = [FakeContent(text)]
+
+@pytest.fixture
+def client():
+    web_frontend.app.config.update({'TESTING': True})
+    with web_frontend.app.test_client() as client:
+        yield client
+
+@pytest.mark.parametrize("mock_result", [
+    [FakeContent("ok")],
+    FakeResult("ok"),
+    {"success": True, "message": "ok"}
+])
+def test_create_project_parsing(monkeypatch, client, mock_result):
+    async def fake_call_tool(name, args):
+        return mock_result
+    monkeypatch.setattr(web_frontend, "call_tool", fake_call_tool)
+
+    resp = client.post('/create_project', data={'name': 'demo', 'description': 'test'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success'] is True
+    assert 'project' in data


### PR DESCRIPTION
## Summary
- add async test for `call_tool` project creation and listing
- test `create_project` route against multiple result formats

## Testing
- `pip install Flask`
- `pip install mcp`
- `pip install pyyaml`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a0263e2ac8324aedd0618d7b84500