### PR TITLE
Add systemd service for auto-updating startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ docker compose up --build
 
 This exposes the web interface on `http://localhost:5000` and stores generated projects under the `projects/` directory.
 
+### Running as a service
+
+If you want the team to run continuously and pull new updates automatically, install the provided systemd service:
+
+```bash
+sudo ./scripts/setup_service.sh
+```
+
+The service launches `start.sh` on boot which updates the repository before starting the server and restarts it on failure.
+
 ## Testing
 
 Basic interaction tests are provided. After installing the requirements you can run:

--- a/config/ai-dev-team.service
+++ b/config/ai-dev-team.service
@@ -6,9 +6,8 @@ After=network.target
 Type=simple
 User=mark
 WorkingDirectory=/home/mark/ai-development-team
-Environment=PATH=/home/mark/ai-development-team/ai-dev-env/bin
 EnvironmentFile=/home/mark/ai-development-team/.env
-ExecStart=/home/mark/ai-development-team/ai-dev-env/bin/python ai_dev_team_server.py
+ExecStart=/home/mark/ai-development-team/start.sh
 Restart=always
 RestartSec=10
 

--- a/scripts/setup_service.sh
+++ b/scripts/setup_service.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Install and enable the AI Development Team systemd service
+set -e
+
+SERVICE_FILE="ai-dev-team.service"
+SERVICE_PATH="/etc/systemd/system/$SERVICE_FILE"
+
+if [ $EUID -ne 0 ]; then
+    echo "This script must be run with sudo or as root" >&2
+    exit 1
+fi
+
+# Copy service file
+cp "$(dirname "$0")/../config/$SERVICE_FILE" "$SERVICE_PATH"
+
+# Reload systemd and enable service
+systemctl daemon-reload
+systemctl enable --now "$SERVICE_FILE"
+
+echo "✅ Service installed and started"


### PR DESCRIPTION
## Summary
- change `ai-dev-team.service` to use `start.sh`
- add helper script to install and enable the service
- document service usage in README

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b45d95d4c83249eb49f298e752256