### PR TITLE
Use Ollama for local LLM

### DIFF
--- a/OLLAMA_SETUP.md
+++ b/OLLAMA_SETUP.md
@@ -1,0 +1,46 @@
+# Ollama Integration Setup
+
+## 1. Install Ollama
+
+1. Visit [Ollama](https://ollama.com/) and follow the install instructions for your operating system.
+2. After installation, start the server:
+
+```bash
+ollama serve &
+```
+
+## 2. Download a Model
+
+Pull one of the recommended models:
+
+```bash
+ollama pull codellama
+ollama pull llama2
+ollama pull mistral
+```
+
+## 3. Configure AI Development Team
+
+Update `config/mcp_config.json` so the server points to Ollama:
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "base_url": "http://localhost:11434/v1",
+    "api_key": "ollama",
+    "model": "codellama"
+  }
+}
+```
+
+## 4. Test Integration
+
+Start the services and create a project:
+
+```bash
+ollama serve &
+python ai_dev_team_server.py
+```
+
+The web interface will be available on `http://localhost:5000`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains a simple example of an **AI-based development team**. I
 - **`templates/index.html`** – HTML template used by the web interface.
 - **Tests** – Scripts such as `test_mcp.py` and `simple_mcp_test.py` show how to interact with the server.
 - **Configuration** – Example systemd service and MCP configuration are located in the `config/` folder.
-- **`LM_STUDIO_SETUP.md`** – Detailed guide for running the project with LM Studio as a local language model.
+- **`OLLAMA_SETUP.md`** – Detailed guide for running the project with Ollama as a local language model.
 - **`verify_agents.py`** – Diagnostic script to confirm all AI agents respond correctly.
 - **`project_templates/`** – Jinja2 templates used when generating new projects.
 - **`config/docker-compose.dev.yml`** – Example Docker Compose setup with Postgres and Redis.
@@ -19,11 +19,11 @@ This repository contains a simple example of an **AI-based development team**. I
 
 ## Setup
 
-1. Run the installation script which sets up the environment, checks for LM Studio and runs the tests. If LM Studio is not running a helper script will install a local Llama backend automatically:
+1. Run the installation script which sets up the environment, checks for Ollama and runs the tests. If Ollama is not running a helper script will install a local Llama backend automatically:
    ```bash
    ./scripts/install.sh
    ```
-   The script will create the `ai-dev-env` virtual environment if needed, install requirements, and verify that a local LM Studio server is running.
+   The script will create the `ai-dev-env` virtual environment if needed, install requirements, and verify that a local Ollama server is running.
 2. (Optional) set environment variables used by the server and web frontend:
    - `GITHUB_TOKEN` and `GITHUB_USERNAME` for GitHub integration.
    - `WORK_DIR` to choose where generated projects are stored (defaults to `./projects`).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,39 +19,26 @@ black .
 echo "Running tests..."
 pytest -q
 
-# 3. Check LM Studio availability
-LM_STUDIO_URL="http://localhost:1234/v1/models"
+# 3. Check Ollama availability
+OLLAMA_URL="http://localhost:11434/api/tags"
 
-echo "Checking LM Studio..."
-if curl -sf "$LM_STUDIO_URL" > /dev/null; then
-    echo "✅ LM Studio server is running"
+echo "Checking Ollama..."
+if curl -sf "$OLLAMA_URL" > /dev/null; then
+    echo "✅ Ollama server is running"
 else
-    echo "⚠️  LM Studio not detected on port 1234"
-    if command -v lmstudio >/dev/null 2>&1; then
-        echo "➡️  Starting LM Studio in server mode"
-        lmstudio --server &
-        sleep 5
-    elif ls LMStudio-*.AppImage >/dev/null 2>&1; then
-        APPIMG=$(ls LMStudio-*.AppImage | head -n1)
-        chmod +x "$APPIMG"
-        "./$APPIMG" --server &
+    echo "⚠️  Ollama not detected on port 11434"
+    if command -v ollama >/dev/null 2>&1; then
+        echo "➡️  Starting Ollama in server mode"
+        ollama serve &
         sleep 5
     else
-        echo "➡️  Downloading LM Studio AppImage..."
-        curl -L -o LMStudio.AppImage "https://github.com/lmstudio-ai/LM-Studio/releases/latest/download/LMStudio-linux-x64.AppImage" || true
-        if [ -f LMStudio.AppImage ]; then
-            chmod +x LMStudio.AppImage
-            ./LMStudio.AppImage --server &
-            sleep 5
-        else
-            echo "❌ Automatic download failed. Please follow LM_STUDIO_SETUP.md"
-        fi
+        echo "❌ Ollama command not found. Please follow OLLAMA_SETUP.md"
     fi
 
-    if curl -sf "$LM_STUDIO_URL" > /dev/null; then
-        echo "✅ LM Studio server started"
+    if curl -sf "$OLLAMA_URL" > /dev/null; then
+        echo "✅ Ollama server started"
     else
-        echo "❌ LM Studio server still not running. See LM_STUDIO_SETUP.md for manual setup"
+        echo "❌ Ollama server still not running. See OLLAMA_SETUP.md for manual setup"
     fi
 fi
 

--- a/scripts/install_llama.sh
+++ b/scripts/install_llama.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Install and test Llama if LM Studio or Llama server is not detected
+# Install and test Llama if Ollama or Llama server is not detected
 set -e
 
-LM_STUDIO_URL="http://localhost:1234/v1/models"
+OLLAMA_URL="http://localhost:11434/api/tags"
 
-# Check LM Studio server
-if curl -sf "$LM_STUDIO_URL" > /dev/null; then
-    echo "✅ LM Studio server detected"
+# Check Ollama server
+if curl -sf "$OLLAMA_URL" > /dev/null; then
+    echo "✅ Ollama server detected"
     exit 0
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,7 +7,7 @@ source ai-dev-env/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
-echo "Checking for LM Studio or local Llama installation..."
+echo "Checking for Ollama or local Llama installation..."
 ./scripts/install_llama.sh
 
 echo "✅ Environment ready. Activate with: source ai-dev-env/bin/activate"


### PR DESCRIPTION
## Summary
- document using Ollama for a local model
- update setup instructions to reference Ollama instead of LM Studio
- automatically start Ollama in install script if available
- update llama fallback script and setup script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd1b90f5883249a36b569af3ddaa7