### PR TITLE
Improve logging and add CLI tests

### DIFF
--- a/ai_dev_team_server.py
+++ b/ai_dev_team_server.py
@@ -148,7 +148,7 @@ async def call_tool(name: str, arguments: dict):
         if not projects:
             return [TextContent(type="text", text="No projects created yet.")]
 
-        logger.debug("Listing %d projects", len(projects))
+        logger.info("Listing %d projects", len(projects))
 
         project_list = "Projects:\n"
         for proj_id, proj in projects.items():
@@ -157,6 +157,7 @@ async def call_tool(name: str, arguments: dict):
         return [TextContent(type="text", text=project_list)]
 
     elif name == "list_agents":
+        logger.info("Listing agents")
         agents = list_default_agents()
         agent_list = "Agents:\n" + "\n".join(f"• {a.name}: {a.purpose}" for a in agents)
         return [TextContent(type="text", text=agent_list)]

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,10 @@
 import asyncio
+import logging
 import typer
 from ai_dev_team_server import call_tool
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("cli")
 
 app = typer.Typer(help="Command line interface for AI Development Team")
 
@@ -8,6 +12,7 @@ app = typer.Typer(help="Command line interface for AI Development Team")
 @app.command()
 def create(name: str, description: str):
     """Create a new project"""
+    logger.info("Creating project %s", name)
     result = asyncio.run(
         call_tool("create_simple_project", {"name": name, "description": description})
     )
@@ -20,6 +25,7 @@ def create(name: str, description: str):
 @app.command()
 def list():
     """List existing projects"""
+    logger.info("Listing projects")
     result = asyncio.run(call_tool("list_projects", {}))
     if result:
         typer.echo(result[0].text)

--- a/run_app.py
+++ b/run_app.py
@@ -8,13 +8,19 @@ can be run with a single command.
 import subprocess
 import sys
 import signal
+import logging
 import web_frontend
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("runner")
 
 
 def main() -> None:
+    logger.info("Starting MCP server")
     server_proc = subprocess.Popen([sys.executable, "ai_dev_team_server.py"])
 
     def shutdown(*_args):
+        logger.info("Shutting down")
         server_proc.terminate()
         server_proc.wait()
 
@@ -22,6 +28,9 @@ def main() -> None:
         signal.signal(signal.SIGINT, lambda *a: shutdown())
         signal.signal(signal.SIGTERM, lambda *a: shutdown())
 
+        logger.info(
+            "Starting web frontend on %s:%s", web_frontend.HOST, web_frontend.PORT
+        )
         web_frontend.app.run(
             debug=True,
             host=web_frontend.HOST,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+from typer.testing import CliRunner
+import cli
+import ai_dev_team_server as server
+
+runner = CliRunner()
+
+
+def test_cli_create_and_list(tmp_path, monkeypatch):
+    server.WORK_DIR = str(tmp_path)
+    server.projects.clear()
+
+    result = runner.invoke(cli.app, ["create", "demo", "demo project"])
+    assert result.exit_code == 0
+    assert "created" in result.output
+
+    result_list = runner.invoke(cli.app, ["list"])
+    assert result_list.exit_code == 0
+    assert "demo" in result_list.output

--- a/tests/test_create_simple_project.py
+++ b/tests/test_create_simple_project.py
@@ -5,6 +5,7 @@ import pytest
 
 import ai_dev_team_server as server
 
+
 @pytest.mark.asyncio
 async def test_call_tool_creates_project(tmp_path, monkeypatch):
     # Use a temporary directory for project creation
@@ -22,6 +23,17 @@ async def test_call_tool_creates_project(tmp_path, monkeypatch):
     project_dir = tmp_path / "demo"
     assert (project_dir / "README.md").exists()
     assert (project_dir / "src" / "main.py").exists()
+
+    # run the generated script to ensure it works
+    proc = await asyncio.create_subprocess_exec(
+        "python",
+        project_dir / "src" / "main.py",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    assert proc.returncode == 0, err.decode()
+    assert "Hello from demo" in out.decode()
 
     # listing should include the project name
     list_result = await server.call_tool("list_projects", {})


### PR DESCRIPTION
## Summary
- add CLI logging for create and list actions
- add logging to run_app and server's list endpoints
- verify generated project can run in tests
- test the CLI with Typer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd71a80e483248d26b371baa9f051