### PR TITLE
Implement DB storage, auth, GitHub integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository contains a simple example of an **AI-based development team**. I
 - **`web_frontend.py`** – Flask application with a form for creating projects using the server.
 - **`cli.py`** – Simple command line tool to create and list projects.
 - **`templates/index.html`** – HTML template used by the web interface.
+- **Persistent storage** – Projects are saved to a SQLite database.
+- **Authentication** – Basic auth can protect the web UI when enabled.
+- **GitHub integration** – New projects may be pushed to GitHub automatically.
 - **Tests** – Scripts such as `test_mcp.py` and `simple_mcp_test.py` show how to interact with the server.
 - **Configuration** – Example systemd service and MCP configuration are located in the `config/` folder.
 - **`OLLAMA_SETUP.md`** – Detailed guide for running the project with Ollama as a local language model.
@@ -27,6 +30,8 @@ This repository contains a simple example of an **AI-based development team**. I
 2. (Optional) set environment variables used by the server and web frontend:
    - `GITHUB_TOKEN` and `GITHUB_USERNAME` for GitHub integration.
    - `WORK_DIR` to choose where generated projects are stored (defaults to `./projects`).
+   - `DB_PATH` to set the SQLite database file for persistent project storage.
+   - `WEB_USERNAME` and `WEB_PASSWORD` to enable basic authentication for the web UI.
    - `FRONTEND_PORT` and `FRONTEND_HOST` to configure the web UI port and host.
    - `LOG_CONFIG` to override the logging configuration file path.
 

--- a/database.py
+++ b/database.py
@@ -1,0 +1,47 @@
+import os
+import sqlite3
+from contextlib import closing
+
+DB_PATH = os.getenv("DB_PATH", os.path.join(os.getcwd(), "projects.db"))
+
+
+def init_db():
+    """Initialize the SQLite database"""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE,
+                description TEXT,
+                path TEXT,
+                created TEXT
+            )"""
+        )
+        conn.commit()
+
+
+def add_project(name: str, description: str, path: str, created: str) -> None:
+    """Add a project to the database"""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute(
+            "INSERT INTO projects (name, description, path, created) VALUES (?, ?, ?, ?)",
+            (name, description, path, created),
+        )
+        conn.commit()
+
+
+def list_projects() -> list[tuple[str, str]]:
+    """Return list of project name/description tuples"""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.execute("SELECT name, description FROM projects ORDER BY id DESC")
+        return cur.fetchall()
+
+
+def get_project(name: str) -> tuple | None:
+    """Retrieve single project info"""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        cur = conn.execute(
+            "SELECT name, description, path, created FROM projects WHERE name=?",
+            (name,),
+        )
+        return cur.fetchone()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from typer.testing import CliRunner
 import cli
 import ai_dev_team_server as server
+import database
 
 runner = CliRunner()
 
@@ -8,6 +9,8 @@ runner = CliRunner()
 def test_cli_create_and_list(tmp_path, monkeypatch):
     server.WORK_DIR = str(tmp_path)
     server.projects.clear()
+    database.DB_PATH = str(tmp_path / "projects.db")
+    database.init_db()
 
     result = runner.invoke(cli.app, ["create", "demo", "demo project"])
     assert result.exit_code == 0

--- a/tests/test_create_simple_project.py
+++ b/tests/test_create_simple_project.py
@@ -4,6 +4,7 @@ import types
 import pytest
 
 import ai_dev_team_server as server
+import database
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,8 @@ async def test_call_tool_creates_project(tmp_path, monkeypatch):
     # Use a temporary directory for project creation
     server.WORK_DIR = str(tmp_path)
     server.projects.clear()
+    database.DB_PATH = str(tmp_path / "projects.db")
+    database.init_db()
 
     result = await server.call_tool(
         "create_simple_project",


### PR DESCRIPTION
## Summary
- persist projects in SQLite via new `database` module
- automatically init git repo and push to GitHub when credentials provided
- protect web UI with optional basic authentication
- update tests for new database usage
- document new environment variables and features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bd8e958488324a4e8fcc0367388bd