### PR TITLE
Implement deletion and health features

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -33,5 +33,27 @@ def list():
         typer.echo("No projects found")
 
 
+@app.command()
+def delete(name: str):
+    """Delete an existing project"""
+    logger.info("Deleting project %s", name)
+    result = asyncio.run(call_tool("delete_project", {"name": name}))
+    if result:
+        typer.echo(result[0].text)
+    else:
+        typer.echo("Failed to delete project")
+
+
+@app.command()
+def agents():
+    """List available agents"""
+    logger.info("Listing agents")
+    result = asyncio.run(call_tool("list_agents", {}))
+    if result:
+        typer.echo(result[0].text)
+    else:
+        typer.echo("No agents found")
+
+
 if __name__ == "__main__":
     app()

--- a/database.py
+++ b/database.py
@@ -54,3 +54,10 @@ def get_project(name: str) -> tuple | None:
             (name,),
         )
         return cur.fetchone()
+
+
+def delete_project(name: str) -> None:
+    """Remove a project from the database"""
+    with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.execute("DELETE FROM projects WHERE name=?", (name,))
+        conn.commit()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,3 +15,19 @@ def test_cli_create_and_list(tmp_path, monkeypatch):
     result_list = runner.invoke(cli.app, ["list"])
     assert result_list.exit_code == 0
     assert "demo" in result_list.output
+
+
+def test_cli_delete_and_agents(tmp_path):
+    prepare_temp_env(tmp_path)
+
+    runner.invoke(cli.app, ["create", "demo", "demo project"])
+    del_result = runner.invoke(cli.app, ["delete", "demo"])
+    assert del_result.exit_code == 0
+    assert "deleted" in del_result.output
+
+    list_result = runner.invoke(cli.app, ["list"])
+    assert "demo" not in list_result.output
+
+    agents_result = runner.invoke(cli.app, ["agents"])
+    assert agents_result.exit_code == 0
+    assert "ProjectManager" in agents_result.output

--- a/tests/test_create_simple_project.py
+++ b/tests/test_create_simple_project.py
@@ -36,3 +36,17 @@ async def test_call_tool_creates_project(tmp_path, monkeypatch):
     # listing should include the project name
     list_result = await server.call_tool("list_projects", {})
     assert any("demo" in block.text for block in list_result)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_delete_project(tmp_path):
+    prepare_temp_env(tmp_path)
+
+    await server.call_tool(
+        "create_simple_project",
+        {"name": "demo", "description": "demo project"},
+    )
+
+    del_result = await server.call_tool("delete_project", {"name": "demo"})
+    assert any("deleted" in block.text for block in del_result)
+    assert not (tmp_path / "demo").exists()

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -21,3 +21,13 @@ def test_api_projects(tmp_path):
         assert resp_detail.status_code == 200
         detail = resp_detail.get_json()
         assert detail["name"] == "demo"
+
+
+def test_api_health(tmp_path):
+    prepare_temp_env(tmp_path)
+    web_frontend.app.config.update({"TESTING": True})
+    with web_frontend.app.test_client() as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "ok"

--- a/web_frontend.py
+++ b/web_frontend.py
@@ -216,6 +216,22 @@ def api_project_detail(name):
     return jsonify({"error": "Not found"}), 404
 
 
+@app.route("/health")
+def health():
+    """Simple health check endpoint"""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        result = loop.run_until_complete(call_tool("health_check", {}))
+    finally:
+        loop.close()
+
+    status = "ok"
+    if isinstance(result, list) and result:
+        status = getattr(result[0], "text", str(result[0]))
+    return jsonify({"status": status})
+
+
 @app.route("/project/<project_name>")
 @requires_auth
 def view_project(project_name):


### PR DESCRIPTION
## Summary
- allow database project deletion
- expose delete and health_check tools in the MCP server
- extend CLI with delete and agents commands
- add `/health` endpoint in the web frontend
- test new CLI, API and server functionality

## Testing
- `pytest -q tests/test_cli.py tests/test_create_simple_project.py tests/test_web_api.py tests/test_web_frontend.py`

------
https://chatgpt.com/codex/tasks/task_e_686d475c2fd48324996faf6b5a4d1412